### PR TITLE
Fix for runtime errors on OS X 10.8.4

### DIFF
--- a/src/mac/_lightblue.py
+++ b/src/mac/_lightblue.py
@@ -557,12 +557,20 @@ class _AsyncDeviceInquiry(Foundation.NSObject):
         if self.cb_completed:
             self.cb_completed(err, aborted)
     deviceInquiryComplete_error_aborted_ = objc.selector(
-        deviceInquiryComplete_error_aborted_, signature="v@:@iB")
+        deviceInquiryComplete_error_aborted_, signature="v@:@iZ")
              
     # - (void)deviceInquiryStarted:(IOBluetoothDeviceInquiry*)sender;             
     def deviceInquiryStarted_(self, inquiry):
         if self.cb_started:
             self.cb_started()
+            
+    # - (void) deviceInquiryDeviceNameUpdated:(IOBluetoothDeviceInquiry*)sender device:(IOBluetoothDevice*)device devicesRemaining:(uint32_t)devicesRemaining;
+    def deviceInquiryDeviceNameUpdated_device_devicesRemaining_(self, sender, device, devicesRemaining):
+        pass
+    
+    # - (void) deviceInquiryUpdatingDeviceNamesStarted:(IOBluetoothDeviceInquiry*)sender devicesRemaining:(uint32_t)devicesRemaining;
+    def deviceInquiryUpdatingDeviceNamesStarted_devicesRemaining_(self, sender, devicesRemaining):
+        pass
         
         
 ### utility methods ###


### PR DESCRIPTION
While this lightblue may very well compile on 10.8, it doesn't really work there, at least it most certainly does not on my 10.8.4 with python 2.7.3 installed from Homebrew.
The problem is missing IOBluetoothDeviceInquiryDelegate protocol method implementations in _AsyncDeviceInquiry and incorrect type encoding string for the - (void) deviceInquiryComplete:(IOBluetoothDeviceInquiry*)sender error:(IOReturn)error aborted:(BOOL)aborted; method.
This fixes both issues.
