### PR TITLE
Enable use on Mac OS X 10.8.x with new method signature & dummy implementations.

### DIFF
--- a/src/mac/_lightblue.py
+++ b/src/mac/_lightblue.py
@@ -535,6 +535,12 @@ class _AsyncDeviceInquiry(Foundation.NSObject):
     def getfounddevices(self):
         return self._inquiry.foundDevices()
         
+    def deviceInquiryDeviceNameUpdated_device_devicesRemaining_(self, sender, device, devicesRemaining):
+        pass
+
+    def deviceInquiryUpdatingDeviceNamesStarted_devicesRemaining_(self, sender, devicesRemaining):
+        pass
+
     def __del__(self):
         super(_AsyncDeviceInquiry, self).dealloc()
         
@@ -557,7 +563,7 @@ class _AsyncDeviceInquiry(Foundation.NSObject):
         if self.cb_completed:
             self.cb_completed(err, aborted)
     deviceInquiryComplete_error_aborted_ = objc.selector(
-        deviceInquiryComplete_error_aborted_, signature="v@:@iB")
+        deviceInquiryComplete_error_aborted_, signature="v@:@iZ")
              
     # - (void)deviceInquiryStarted:(IOBluetoothDeviceInquiry*)sender;             
     def deviceInquiryStarted_(self, inquiry):


### PR DESCRIPTION
Without this patch 10.8.2 does not work--contrary to what our README for libpebble suggests.

I'm proposing pulling this into master on the assumption that 10.8.2 & 10.8.3 are the most common 10.8 versions in the wild so we should support them out of the box.

For more details see the commit message.
