### PR TITLE
Fix 10.9 support

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -63,4 +63,4 @@ if MAC:
     if "install" in sys.argv:
         import os
         os.chdir("src/mac/LightAquaBlue")
-        os.system("xcodebuild install -arch '$(NATIVE_ARCH_ACTUAL)' -target LightAquaBlue -configuration Release DSTROOT=/ INSTALL_PATH=/Library/Frameworks DEPLOYMENT_LOCATION=YES")
+        os.system("xcodebuild install -arch $(uname -m) -target LightAquaBlue -configuration Release DSTROOT=/ INSTALL_PATH=/Library/Frameworks DEPLOYMENT_LOCATION=YES")

--- a/src/mac/_lightblue.py
+++ b/src/mac/_lightblue.py
@@ -475,6 +475,13 @@ class _AsyncPair(Foundation.NSObject):
     devicePairingFinished_error_ = objc.selector(
         devicePairingFinished_error_, signature="v@:@i")
 
+    # - (void) deviceSimplePairingComplete:(id)sender
+    #                               status:(BluetoothHCIEventStatus)status
+    def deviceSimplePairingComplete_status_(self, sender, status):
+        print "deviceSimplePairingComplete_status_: %u" % status
+    deviceSimplePairingComplete_status_ = objc.selector(
+        deviceSimplePairingComplete_status_, signature="v@:@C")
+
 # Wrapper around IOBluetoothDeviceInquiry, with python callbacks that you can
 # set to receive callbacks when the inquiry is started or stopped, or when it
 # finds a device.


### PR DESCRIPTION
Not only is NATIV_ARCH_ACTUAL missing in 10.9, even if it was exported, it wouldn't get used because of single quotes. This uses uname -m instead.

A new deviceSimplePairingComplete method is also implemented.
